### PR TITLE
Added HeadLess support 

### DIFF
--- a/demo/presets.js
+++ b/demo/presets.js
@@ -23,7 +23,7 @@ export default [
     },
     {
         name: 'layoutsTabs',
-        displayName: 'Layouts - Tabs (Experimental)',
+        displayName: 'Layouts - Tabs',
         entityName: 'contact',
         layoutName: 'edit',
         formTitle: 'Edit contact',

--- a/src/components/group/Group.js
+++ b/src/components/group/Group.js
@@ -26,9 +26,10 @@ class Group extends BaseGroup {
         let {layout} = this.props;
         let content = this.getContent();
         let header = (!layout.headLess)? this.getHeader() : null;
+        const style = (layout.headLess)? { marginTop: "15px" } : null;
 
         return (
-            <section>
+            <section style={style}>
                 <div className='row'>
                     <div className="metaform-group">
                         { header }

--- a/src/components/group/Group.js
+++ b/src/components/group/Group.js
@@ -9,13 +9,10 @@ class Group extends BaseGroup {
         componentFactory: PropTypes.object.isRequired
     };
 
-    render() {
-
+    getHeader = () => {
         let {layout} = this.props;
-        let content = this.getContent();
 
-        // Group header
-        let header = layout.title
+        return layout.title
             ? (
             <header className="metaform-group-header">
                 <span className="metaform-group-title">
@@ -23,6 +20,12 @@ class Group extends BaseGroup {
                 </span>
             </header>
         ) : null;
+    };
+
+    render() {
+        let {layout} = this.props;
+        let content = this.getContent();
+        let header = (!layout.headLess)? this.getHeader() : null;
 
         return (
             <section>

--- a/src/components/group/TabGroup.js
+++ b/src/components/group/TabGroup.js
@@ -14,6 +14,51 @@ class TabGroup extends BaseGroup {
 		position: 0
 	};
 
+    getComponents = () => {
+        let { layout, componentFactory, fields } = this.props;
+        let components;
+
+        if (layout.fields) {
+
+            components = layout.fields.map(field => {
+                let fieldMetadata = fields.find(cp => cp.name === field.name);
+
+                if (!fieldMetadata) {
+                    throw Error(`Could not find field. Field: ${field.name}`);
+                }
+
+                // in case the field is going to render layouts internally, it's going to need information about the
+                // layout and fields. I'm not sure if this is the best way to do it, probably not. TODO: Review it.
+                fieldMetadata._extra = {layout, fields};
+
+                return {
+                    data: fieldMetadata,
+                    length: layout.fields.length,
+                    component: componentFactory.buildFieldComponent(fieldMetadata)
+                }
+            });
+
+        } else if (layout.groups) {
+
+            components = layout.groups.map(group => {
+                group = {...group, headLess: true};
+
+                return {
+                    data: group,
+                    length: layout.groups.length,
+                    component: componentFactory.buildGroupComponent({
+                        component: group.component,
+                        layout: group,
+                        fields: fields,
+                        componentFactory: componentFactory
+                    })
+                }
+            });
+        }
+
+        return components;
+    };
+
 	onNavItemSelected = (eventKey) => {
 		this.setState({ position: eventKey });
 	};


### PR DESCRIPTION
@andrerpena This PR fix the last issue with TabGroup #26 that was the headLess group. This is currently solved by override the function getComponents() in TabGroup so in child group generation I merge the subcomponents layout with a prop called headLess that I set to true. 

``` javascript
       } else if (layout.groups) {
            components = layout.groups.map(group => {

                //HERE THE MAGIC HAPPENS..
                group = {...group, headLess: true};

                return {
                    data: group,
                    length: layout.groups.length,
                    component: componentFactory.buildGroupComponent({
                        component: group.component,
                        layout: group,
                        fields: fields,
                        componentFactory: componentFactory
                    })
                }
            });
        }
```
